### PR TITLE
Update markdown broken rendering (main README)

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ brew install coreutils
 ## What it does
 
 When you start the script, it prepares some variables and checks if the file
-[a] or directory [b] given as input really exists.
+or directory given as input really exists.
 
 Then it goes into the main loop (which will run forever, until the script is
 forcefully stopped/killed), which will:
@@ -111,13 +111,14 @@ forcefully stopped/killed), which will:
 * watch for changes to the file/directory using `inotifywait` (`inotifywait`
   will block until something happens)
 * wait 2 seconds
-* `cd` into the directory [b] / the directory containing the file [a]
-  \(because `git` likes to operate locally)
-* `git add <file>`[a] / `git add .`[b]
-* `git commit -m "Scripted auto-commit on change (<date>)"`[a] / `git commit
-<!-- markdownlint-disable -->
-  -a -m"Scripted auto-commit on change (<date>)"`[b]
-<!-- markdownlint-enable -->
+* case file:
+  * `cd` into the directory containing the file (because `git` likes to operate locally)
+  * `git add <file>`
+  * `git commit -m "Scripted auto-commit on change (<date>)"`
+* case directory:
+  * `cd` into the directory  (because `git` likes to operate locally)
+  * `git add .`
+  * `git commit -a -m "Scripted auto-commit on change (<date>)"`
 * if a remote is defined (with `-r`) do a push after the commit (a specific
   branch can be selected with `-b`)
 


### PR DESCRIPTION
Redesigned bullet points of the actions taken by the script for file / directory.

Question: the commit commands differ with the parameter `-a` between the two cases. If required, I can change that as well - I am not sure, however, if this is intentional or not.

Before:

![image](https://user-images.githubusercontent.com/59165496/143209885-cc2836bf-8cd2-47e6-84cd-62e5c3569f4a.png)

After:

![image](https://user-images.githubusercontent.com/59165496/143209980-d00e6510-9d47-41da-b349-57978d3752f6.png)

